### PR TITLE
Plancklensdev

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to plancklens documentation!
    n0
    n1
    qresp
+   patchy
 
 Indices and tables
 ==================

--- a/docs/n0.rst
+++ b/docs/n0.rst
@@ -2,5 +2,5 @@
 plancklens.n0s
 ==============
 
-.. automodule:: plancklens.n0s
-    :members: get_N0, get_N0_iter
+.. automodule:: plancklens.patchy
+    :members: get_N0, ge

--- a/docs/patchy.rst
+++ b/docs/patchy.rst
@@ -1,0 +1,6 @@
+=================
+plancklens.patchy
+=================
+
+.. automodule:: plancklens.patchy.patchy
+    :members: get_patchy_N0s, mk_patches, get_ivf_cls, get_responses, get_nhls

--- a/plancklens/filt/filt_util.py
+++ b/plancklens/filt/filt_util.py
@@ -121,17 +121,17 @@ class library_fml:
     def get_ftl(self):
         m_rescal = 2 * np.cumsum(self.mfilt_t[:self.lmax + 1]) - self.mfilt_t[0]
         m_rescal /= (2 * np.arange(self.lmax + 1) + 1)
-        return self.ivfs.get_ftl()[:self.lmax + 1] * m_rescal
+        return self.ivfs.get_ftl()[:self.lmax + 1] * np.sqrt(m_rescal) # root has better chance to work at the spectrum level
 
     def get_fel(self):
         m_rescal = 2 * np.cumsum(self.mfilt_e[:self.lmax + 1]) - self.mfilt_e[0]
         m_rescal /= (2 * np.arange(self.lmax + 1) + 1)
-        return self.ivfs.get_fel()[:self.lmax + 1] * np.sum(self.mfilt_e[:self.lmax + 1]) / (2 * np.arange(self.lmax + 1) + 1)
+        return self.ivfs.get_fel()[:self.lmax + 1] * np.sqrt(m_rescal)
 
     def get_fbl(self):
         m_rescal = 2 * np.cumsum(self.mfilt_b[:self.lmax + 1]) - self.mfilt_b[0]
         m_rescal /= (2 * np.arange(self.lmax + 1) + 1)
-        return self.ivfs.get_fbl()[:self.lmax + 1] * np.sum(self.mfilt_b[:self.lmax + 1]) / (2 * np.arange(self.lmax + 1) + 1)
+        return self.ivfs.get_fbl()[:self.lmax + 1] * np.sqrt(m_rescal)
 
     def get_sim_tlm(self, idx):
         return self.almxfm(self.ivfs.get_sim_tlm(idx), self.mfilt_t, self.lmax)

--- a/plancklens/n1/n1.py
+++ b/plancklens/n1/n1.py
@@ -141,7 +141,7 @@ class library_n1:
 
     def get_n1(self, kA, k_ind, cl_kind, ftlA, felA, fblA, Lmax, kB=None, ftlB=None, felB=None, fblB=None,
                clttfid=None, cltefid=None, cleefid=None, n1_flat=lambda ell: np.ones(len(ell), dtype=float),
-               recache=False, sglLmode=True):
+               recache=False, remove_only=False, sglLmode=True):
         r"""Calls a N1 bias
 
             Args:
@@ -204,10 +204,12 @@ class library_n1:
 
             ret = self.npdb.get(idx)
             if ret is not None:
-                if not recache:
+                if not recache and not remove_only:
                     return ret
                 else:
                     self.npdb.remove(idx)
+                    if remove_only:
+                        return np.zeros_like(ret)
                     ret = None
             if ret is None:
                 Ls = np.unique(np.concatenate([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], np.arange(1, Lmax + 1)[::20], [Lmax]]))

--- a/plancklens/n1/n1.py
+++ b/plancklens/n1/n1.py
@@ -140,7 +140,8 @@ class library_n1:
                 'dL': self.dL, 'lps': self.lps}
 
     def get_n1(self, kA, k_ind, cl_kind, ftlA, felA, fblA, Lmax, kB=None, ftlB=None, felB=None, fblB=None,
-               clttfid=None, cltefid=None, cleefid=None, n1_flat=lambda ell: np.ones(len(ell), dtype=float), sglLmode=True):
+               clttfid=None, cltefid=None, cleefid=None, n1_flat=lambda ell: np.ones(len(ell), dtype=float),
+               recache=False, sglLmode=True):
         r"""Calls a N1 bias
 
             Args:
@@ -201,7 +202,14 @@ class library_n1:
             idx += '_cleefid' + clhash(cleefid)
             idx += '_Lmax%s' % Lmax
 
-            if self.npdb.get(idx) is None:
+            ret = self.npdb.get(idx)
+            if ret is not None:
+                if not recache:
+                    return ret
+                else:
+                    self.npdb.remove(idx)
+                    ret = None
+            if ret is None:
                 Ls = np.unique(np.concatenate([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], np.arange(1, Lmax + 1)[::20], [Lmax]]))
                 if sglLmode:
                     n1L = np.zeros(len(Ls), dtype=float)
@@ -225,6 +233,7 @@ class library_n1:
                 ret[1:] =  spline(Ls, np.array(n1L) * n1_flat(Ls), s=0., ext='raise', k=3)(np.arange(1, Lmax + 1) * 1.)
                 ret[1:] *= cli(n1_flat(np.arange(1, Lmax + 1) * 1.))
                 self.npdb.add(idx, ret)
+                return ret
             return self.npdb.get(idx)
 
         if (kA in estimator_keys_derived) and (kB in estimator_keys_derived):

--- a/plancklens/nhl.py
+++ b/plancklens/nhl.py
@@ -13,7 +13,7 @@ from plancklens.helpers import mpi, sql
 
 
 def get_nhl(qe_key1, qe_key2, cls_weights, cls_ivfs, lmax_ivf1, lmax_ivf2,
-            lmax_out=None, lmax_ivf12=None, lmax_ivf22=None, cls_ivfs_bb=None, cls_ivfs_ab=None):
+            lmax_out=None, lmax_ivf12=None, lmax_ivf22=None, cls_weights2=None, cls_ivfs_bb=None, cls_ivfs_ab=None):
     """(Semi-)Analytical noise level calculation for the cross-spectrum of two QE keys.
 
         Args:
@@ -26,6 +26,7 @@ def get_nhl(qe_key1, qe_key2, cls_weights, cls_ivfs, lmax_ivf1, lmax_ivf2,
             lmax_ivf1: QE 1 uses CMB multipoles down to lmax_ivf1.
             lmax_ivf2: QE 2 uses CMB multipoles down to lmax_ivf2.
             lmax_out(optional): outputs are calculated down to lmax_out. Defaults to lmax_ivf1 + lmax_ivf2
+            cls_weights2(optional): Second QE cls weights, if different from cls_weights
 
         Outputs:
             4-tuple of gradient (G) and curl (C) mode Gaussian noise co-variances GG, CC, GC, CG.
@@ -33,8 +34,9 @@ def get_nhl(qe_key1, qe_key2, cls_weights, cls_ivfs, lmax_ivf1, lmax_ivf2,
     """
     if lmax_ivf12 is None: lmax_ivf12 = lmax_ivf1
     if lmax_ivf22 is None: lmax_ivf22 = lmax_ivf2
+    if cls_weights2 is None: cls_weights2 = cls_weights
     qes1 = qresp.get_qes(qe_key1, lmax_ivf1, cls_weights, lmax2=lmax_ivf12)
-    qes2 = qresp.get_qes(qe_key2, lmax_ivf2, cls_weights, lmax2=lmax_ivf22)
+    qes2 = qresp.get_qes(qe_key2, lmax_ivf2, cls_weights2, lmax2=lmax_ivf22)
     if lmax_out is None:
         lmax_out = max(lmax_ivf1, lmax_ivf12) + max(lmax_ivf2, lmax_ivf22)
     return  _get_nhl(qes1, qes2, cls_ivfs, lmax_out, cls_ivfs_bb=cls_ivfs_bb, cls_ivfs_ab=cls_ivfs_ab)

--- a/plancklens/qecl.py
+++ b/plancklens/qecl.py
@@ -78,7 +78,11 @@ class library(object):
     def get_lmaxqcl(self, k1, k2):
         return min(self.qeA.get_lmax_qlm(k1), self.qeB.get_lmax_qlm(k2))
 
-    def get_sim_qcl(self, k1, idx, k2=None, lmax=None, recache=False):
+    def load_sim_qcl(self, k1, idx, k2=None, lmax=None):
+        """Same as get_sim_qcl without triggering its calculation"""
+        return self.get_sim_qcl(k1, idx, k2=k2, lmax=lmax, calc=False)
+
+    def get_sim_qcl(self, k1, idx, k2=None, lmax=None, recache=False, calc=True):
         """Returns QE (cross-)power spectrum for a simulation index.
 
             Args:
@@ -86,6 +90,7 @@ class library(object):
                 idx: simulation index
                 k2: QE anisotropy key 2 (defaults to k1)
                 lmax: optionally reduce the output to multipole lmax
+                calc: calculates it if not done already. Otherwise throws an error if set to False
 
             Returns:
                QE power spectrum (1d array)
@@ -102,7 +107,9 @@ class library(object):
         else:
             assert idx ==-1
             fname = os.path.join(self.lib_dir, 'sim_qcl_k1%s_k2%s_lmax%s_dat_%s.dat' % (k1, k2, lmax_qcl, self._mcmf_hash()))
-        if self.npdb.get(fname) is None or recache:
+        if calc:
+            recache=False
+        if calc and (self.npdb.get(fname) is None or recache):
             qlmA = self.qeA.get_sim_qlm(k1, idx, lmax=lmax_qcl)
             qlmA -= self.qeA.get_sim_qlm_mf(k1, self.mc_sims_mf[0::2], lmax=lmax_qcl)
             qlmB = self.qeB.get_sim_qlm(k2, idx, lmax=lmax_qcl)

--- a/plancklens/qest.py
+++ b/plancklens/qest.py
@@ -310,6 +310,12 @@ class library:
         Q2, U2 = (self.f2map2.get_pmap(idx, joint=joint) if not swapped else self.f2map1.get_pmap(idx, joint=joint))
         return -4. * hp.map2alm(Q1 * U2 -  U1 * Q2 , lmax=self.get_lmax_qlm('P'), iter=0)
 
+    def _get_sim_MVgclm(self, idx, k, swapped=False):
+        assert k == 'p'
+        GP, CP = self._get_sim_Pgclm(idx, 'p', swapped=swapped)
+        GT, CT = self._get_sim_Tgclm(idx, 'p', swapped=swapped)
+        return GP + GT, CP + GT
+
     def _build_sim_Tgclm(self, idx):
         """ T only lensing potentials estimators """
         G, C = self._get_sim_Tgclm(idx, 'ptt')
@@ -338,22 +344,15 @@ class library:
 
     def _build_sim_MVgclm(self, idx):
         """ MV. lensing potentials estimators """
-        G, C = self._get_sim_Pgclm(idx, 'p')
+        G, C = self._get_sim_MVgclm(idx, 'p')
         if not self.f2map1.ivfs == self.f2map2.ivfs:
-            _G, _C = self._get_sim_Pgclm(idx, 'p', swapped=True)
+            _G, _C = self._get_sim_MVgclm(idx, 'p', swapped=True)
             G = 0.5 * (G + _G)
             del _G
             C = 0.5 * (C + _C)
             del _C
-        GT, CT = self._get_sim_Tgclm(idx, 'p')
-        if not self.f2map1.ivfs == self.f2map2.ivfs:
-            _G, _C = self._get_sim_Tgclm(idx, 'p', swapped=True)
-            GT = 0.5 * (GT + _G)
-            del _G
-            CT = 0.5 * (CT + _C)
-            del _C
-        _write_alm(os.path.join(self.lib_dir, 'sim_p_%04d.fits'%idx if idx != -1 else 'dat_p.fits'), G + GT)
-        _write_alm(os.path.join(self.lib_dir, 'sim_x_%04d.fits'%idx if idx != -1 else 'dat_x.fits'), C + CT)
+        _write_alm(os.path.join(self.lib_dir, 'sim_p_%04d.fits'%idx if idx != -1 else 'dat_p.fits'), G)
+        _write_alm(os.path.join(self.lib_dir, 'sim_x_%04d.fits'%idx if idx != -1 else 'dat_x.fits'), C)
 
     def _build_sim_f(self, idx):
         """ MV. modulation estimators. """

--- a/plancklens/sims/planck2018_sims.py
+++ b/plancklens/sims/planck2018_sims.py
@@ -16,7 +16,8 @@ class smica_dx12:
     r""" SMICA 2018 release simulation and data library at NERSC.
 
         Note:
-
+            This now converts all maps to double precision
+            (healpy 1.15 changed read_map default type behavior, breaking in a way that is not very clear as yet the behavior of the conjugate gradient inversion chain)
     """
     def __init__(self):
         self.cmbs = '/project/projectdirs/cmb/data/planck2018/ffp10/compsep/mc_cmb/dx12_v3_smica_cmb_mc_%05d_005a_2048.fits'
@@ -38,10 +39,10 @@ class smica_dx12:
         """
         if idx == -1:
             return self.get_dat_tmap()
-        return 1e6 * (hp.read_map(self.cmbs % idx, field=0) + hp.read_map(self.noise % idx, field=0))
+        return 1e6 * (hp.read_map(self.cmbs % idx, field=0, dtype=np.float64) + hp.read_map(self.noise % idx, field=0, dtype=np.float64))
 
     def get_dat_tmap(self):
-        return 1e6 * hp.read_map(self.data, field=0)
+        return 1e6 * hp.read_map(self.data, field=0, dtype=np.float64)
 
     def get_sim_pmap(self, idx):
         r"""Returns dx12 SMICA polarization map for a simulation
@@ -55,12 +56,12 @@ class smica_dx12:
         """
         if idx == -1:
             return self.get_dat_pmap()
-        Q = 1e6 * (hp.read_map(self.cmbs % idx, field=1) + hp.read_map(self.noise % idx, field=1))
-        U = 1e6 * (hp.read_map(self.cmbs % idx, field=2) + hp.read_map(self.noise % idx, field=2))
+        Q = 1e6 * (hp.read_map(self.cmbs % idx, field=1, dtype=np.float64) + hp.read_map(self.noise % idx, field=1, dtype=np.float64))
+        U = 1e6 * (hp.read_map(self.cmbs % idx, field=2, dtype=np.float64) + hp.read_map(self.noise % idx, field=2, dtype=np.float64))
         return Q, U
 
     def get_dat_pmap(self):
-        return 1e6 * hp.read_map(self.data, field=1), 1e6 * hp.read_map(self.data, field=2)
+        return 1e6 * hp.read_map(self.data, field=1, dtype=np.float64), 1e6 * hp.read_map(self.data, field=2, dtype=np.float64)
 
 class ffp10cmb_widnoise:
     r"""Simulation library with freq-0 FFP10 lensed CMB together with idealized, homogeneous noise.

--- a/plancklens/utils.py
+++ b/plancklens/utils.py
@@ -117,6 +117,9 @@ def clhash(cl, dtype=np.float16):
 
     By default we avoid here double precision checks since this might be machine dependent.
 
+        Note: casting to low precision can be a really bad choice for small numbers...
+
+
     """
     return hashlib.sha1(np.copy(cl.astype(dtype), order='C')).hexdigest()
 
@@ -322,6 +325,7 @@ def camb_clfile(fname, lmax=None):
         cls['pe'][ell[idc]] = cols[7][idc] / wptpe(ell[idc])
     return cls
 
+
 def cl_inverse(cls):
     """Inverse of T E B spectral matrices. Input and ouputs are dictionaries.
 
@@ -369,7 +373,7 @@ def _cldict2arr(cls_dict):
             ret[i, j] =  extcl(lmaxp1 - 1, cls_dict.get(x + y, cls_dict.get(y + x, np.array([0.]))))
     return ret
 
-def cls_dot(cls_list):
+def cls_dot(cls_list, ret_dict=False):
     """T E B spectral matrices product
 
         Args:
@@ -389,4 +393,11 @@ def cls_dot(cls_list):
         for j in range(3):
             for k in range(3):
                 ret[i, j] += cls_0[i, k] * cls[k, j]
+    if ret_dict:
+        clsi = {}
+        for k, (i, j) in zip(['tt', 'ee', 'bb', 'te', 'tb', 'eb'], [[0, 0], [1, 1], [2, 2], [0, 1], [0, 2], [1, 2]]):
+            arr = ret[i, j, :].copy()
+            if np.any(arr):
+                clsi[k] = arr
+        return clsi
     return ret

--- a/plancklens/utils_spin.py
+++ b/plancklens/utils_spin.py
@@ -105,8 +105,11 @@ def get_spin_lower(s, lmax):
 def _dict_transpose(cls):
     ret = {}
     for k in cls.keys():
-        assert len(k) == 2
-        ret[k[1] + k[0]] = np.copy(cls[k])
+        if len(k) == 1:
+            ret[k + k] = np.copy(cls[k])
+        else:
+            assert len(k) == 2
+            ret[k[1] + k[0]] = np.copy(cls[k])
     return ret
 
 
@@ -130,13 +133,13 @@ def spin_cls(s1, s2, cls):
     elif s1 == 2:
         if s2 == 0:
             assert 'te' in cls.keys() or 'et' in cls.keys()
-            tb = cls.get('bt', cls.get('tb', None), None)
+            tb = cls.get('bt', cls.get('tb', None))
             et = cls.get('et', cls.get('te'))
             return  -et if tb is None else  -et - 1j * tb
         elif s2 == 2:
             return cls['ee'] + cls['bb']
         elif s2 == -2:
-            eb = cls.get('be', cls.get('eb', None), None)
+            eb = cls.get('be', cls.get('eb', None))
             return  cls['ee'] - cls['bb'] if eb is None else  cls['ee'] - cls['bb'] + 2j * eb
         else:
             assert 0

--- a/plancklens/utils_spin.py
+++ b/plancklens/utils_spin.py
@@ -102,28 +102,41 @@ def get_spin_lower(s, lmax):
     ret[abs(s):] = -np.sqrt(np.arange(s + abs(s), lmax + s + 1) * np.arange(abs(s) - s + 1, lmax - s + 2))
     return ret
 
+def _dict_transpose(cls):
+    ret = {}
+    for k in cls.keys():
+        assert len(k) == 2
+        ret[k[1] + k[0]] = np.copy(cls[k])
+    return ret
+
+
 def spin_cls(s1, s2, cls):
     r"""Spin-weighted power spectrum :math:`_{s1}X_{lm} _{s2}X^{*}_{lm}`
 
         The output is real unless necessary.
 
+
     """
     if s1 < 0:
-        return (-1) ** (s1 + s2) * np.conjugate(spin_cls(-s1, -s2, cls))
+        return (-1) ** (s1 + s2) * np.conjugate(spin_cls(-s1, -s2, _dict_transpose(cls)))
     assert s1 in [0, -2, 2] and s2 in [0, -2, 2], (s1, s2, 'not implemented')
     if s1 == 0:
         if s2 == 0:
             return cls['tt']
         tb = cls.get('tb', None)
-        return  -cls['te'] if tb is None else  -cls['te'] + 1j * np.sign(s2) * tb
+        assert 'te' in cls.keys() or 'et' in cls.keys()
+        te = cls.get('te', cls.get('et'))
+        return  -te if tb is None else  -te + 1j * np.sign(s2) * tb
     elif s1 == 2:
         if s2 == 0:
-            tb = cls.get('tb', None)
-            return  -cls['te'] if tb is None else  -cls['te'] - 1j * tb
+            assert 'te' in cls.keys() or 'et' in cls.keys()
+            tb = cls.get('bt', cls.get('tb', None), None)
+            et = cls.get('et', cls.get('te'))
+            return  -et if tb is None else  -et - 1j * tb
         elif s2 == 2:
             return cls['ee'] + cls['bb']
         elif s2 == -2:
-            eb = cls.get('eb', None)
+            eb = cls.get('be', cls.get('eb', None), None)
             return  cls['ee'] - cls['bb'] if eb is None else  cls['ee'] - cls['bb'] + 2j * eb
         else:
             assert 0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md", "r") as fh:
 
 def configuration(parent_package='', top_path=''):
     config = Configuration('', parent_package, top_path)
+    # try extra_link_args = ['-lgomp', '-qopenmp'] was useful at some point for intel compilers (Kareem)
     config.add_extension('plancklens.wigners.wigners', ['plancklens/wigners/wigners.f90'],
                          extra_link_args=['-lgomp'], libraries=['gomp'], extra_f90_compile_args=['-fopenmp', '-w'])
     config.add_extension('plancklens.n1.n1f', ['plancklens/n1/n1f.f90'],


### PR DESCRIPTION
prel. fix to healpy 1.15 version changing the default type of read_map. This was causing feeding single precision maps to the filtering of the SMICA dx12 maps, with very bad chain behavior.