### PR TITLE
Typo in get_n0_iter and duplicate function

### DIFF
--- a/plancklens/nhl.py
+++ b/plancklens/nhl.py
@@ -322,7 +322,7 @@ def get_N0_iter(qe_key:str, nlev_t:float, nlev_p:float, beam_fwhm:float, cls_unl
         dat_delcls = {}
         if qe_key in ['ptt', 'p']:
             fal['tt'] = cls_filt['tt'][:lmax_ivf + 1] + (nlev_t * np.pi / 180. / 60.) ** 2 * transfi2
-            dat_delcls['tt'] = cls_plen_true['tt'][:lmax_ivf + 1] + datnoise_cls['ee']
+            dat_delcls['tt'] = cls_plen_true['tt'][:lmax_ivf + 1] + datnoise_cls['tt']
         if qe_key in ['p_p', 'p']:
             fal['ee'] = cls_filt['ee'][:lmax_ivf + 1] + (nlev_p * np.pi / 180. / 60.) ** 2 * transfi2
             fal['bb'] = cls_filt['bb'][:lmax_ivf + 1] + (nlev_p * np.pi / 180. / 60.) ** 2 * transfi2


### PR DESCRIPTION
It seems there is a typo in the function nhl.get_N0_iter where it sums the datnoise_cls['ee'] instead of datnoise_cls['tt] to the partially delensed cls. 
Also, this function get_N0_iter is present two times, one in nhl.py and one in n0s.py, and the typo is also present in the n0s.py file.
I would suggest to only keep one of the two functions to avoid mistakes ?