### PR TITLE
Update filt_cinv.py

### DIFF
--- a/plancklens/filt/filt_cinv.py
+++ b/plancklens/filt/filt_cinv.py
@@ -327,7 +327,7 @@ class cinv_p(cinv):
 
     def _ninv_hash(self):
         ret = []
-        for ninv_comp in self.ninv[0]:
+        for ninv_comp in self.ninv:
             if isinstance(ninv_comp, np.ndarray) and ninv_comp.size > 1:
                 ret.append(utils.clhash(ninv_comp))
             else:


### PR DESCRIPTION
Fixes hashing bug for ninv, as an element of ninv[0] would never be a instance of np.ndarray, but ninv[0] is

@carronj pls review and merge if you like