### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
 healpy
 six
 scipy
+numpy<1.23
+setuptools<65.0


### PR DESCRIPTION
Fix for numpy, because distutils is deprecated.
The best would be to udpate the setup procedure to match latest python and versions. 